### PR TITLE
docker: Add build file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# .dockerignore
+Dockerfile
+# .gitignore
+*.build
+*.buildinfo
+*.changes
+*.deb
+*.debian.tar.xz
+*.dsc
+/debian/.debhelper/
+/debian/debhelper-build-stamp
+/debian/files
+/debian/webthings-gateway.substvars
+/debian/webthings-gateway/
+/webthings-gateway/
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+#{
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+#}
+
+FROM debian:10 as webthings-gateway-builder
+LABEL maintainer="Philippe Coval <rzr@users.sf.net>"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL en_US.UTF-8
+ENV LANG ${LC_ALL}
+
+RUN echo "#log: Configuring locales and setting up system" \
+  && set -x \
+  && apt update \
+  && apt install -y locales sudo \
+  && echo "${LC_ALL} UTF-8" | tee /etc/locale.gen \
+  && locale-gen ${LC_ALL} \
+  && dpkg-reconfigure locales \
+  && apt clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && sync
+
+ENV project webthings-gateway
+
+ENV workdir /usr/local/opt/${project}/src/${project}
+COPY . ${workdir}
+WORKDIR ${workdir}
+RUN echo "#log: ${project}: Preparing sources" \
+  && set -x \
+  && ./build.sh \
+  && install -d /usr/local/opt/${project}/dist \
+  && install ${project}*.* /usr/local/opt/${project}/dist \
+  && sync
+
+
+FROM debian:10
+LABEL maintainer="Philippe Coval <rzr@users.sf.net>"
+ENV project webthings-gateway
+COPY --from=webthings-gateway-builder /usr/local/opt/${project}/dist /usr/local/opt/${project}/dist
+WORKDIR /usr/local/opt/${project}/dist
+
+RUN echo "# log: ${project}: Installing" \
+  && set -x \
+  && find ${PWD} \
+  && apt-get update -y \
+  && apt install -y ./${project}_*.deb \
+  && apt-get install -f -y \
+  && dpkg -L ${project} \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && sync
+
+ENTRYPOINT [ "/usr/bin/webthings-gateway" ]

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# -*- mode: Bash; tab-width: 2; indent-tabs-mode: t; -*-
+#{
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/ .
+#}
+
+set -e -x
+
+project="webthings-gateway"
+dir="/usr/local/opt/${project}/dist"
+repository="gatewaydeb_default"
+tag="latest"
+image="${repository}:${tag}"
+
+
+cd "$(readlink -f $(dirname "$0"))"
+
+docker version
+
+docker build -t "${repository}" .
+container=$(docker create "$image")
+docker cp "$container:$dir/" ./

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 9), nodejs (>= 8), npm, git, python, python3, pytho
 
 Package: webthings-gateway
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, {{nodejs}}, pagekite, {{python3}}, python3-pip, libnanomsg4 | libnanomsg5, libffi6, adduser, sudo
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, {{nodejs}}, pagekite, lsb-release,
+ {{python3}}, python3-pip, libnanomsg4 | libnanomsg5, libffi6, adduser, sudo
 Recommends: arping, avahi-daemon, ffmpeg, mosquitto, sqlite3
 Description: WebThings Gateway by Mozilla
  Web of Things gateway, created by Mozilla, which can bridge existing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MPL-2.0
+
+version: "2"
+
+services:
+  default:
+    build: .
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
This can be useful for building from git,

For example on odroid-xu4, I was able to build:

    webthings-gateway_0.11.0-1_armhf-debian-buster.deb

Using docker:

    docker build -t gateway-deb \
      https://github.com/CrossStream/gateway-deb.git

Relate-to: https://twitter.com/RzrFreeFr/status/1230918703107190784
Change-Id: I4dfad531198fff9f37f04c429c01aee0edcc6b5b
Signed-off-by: Philippe Coval <rzr@users.sf.net>